### PR TITLE
added FT_Size_Request_Type enum and FT_Size_RequestRec

### DIFF
--- a/FreeTypeSharp/Native/FT.Methods.cs
+++ b/FreeTypeSharp/Native/FT.Methods.cs
@@ -216,7 +216,7 @@ namespace FreeTypeSharp.Native
         
 
         [DllImport(FreeTypeLibaryName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern FT_Error FT_Request_Size(IntPtr face, IntPtr req);
+        public static extern FT_Error FT_Request_Size(IntPtr face, ref FT_Size_RequestRec req);
         
 
         [DllImport(FreeTypeLibaryName, CallingConvention = CallingConvention.Cdecl)]

--- a/FreeTypeSharp/Native/FT_Size_RequestRec.cs
+++ b/FreeTypeSharp/Native/FT_Size_RequestRec.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using FT_Long = System.UInt64;
+using FT_UInt = System.UInt32;
+
+namespace FreeTypeSharp.Native
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct FT_Size_RequestRec
+    {
+        public FT_Size_Request_Type type;
+        public FT_Long width;
+        public FT_Long height;
+        public FT_UInt horiResolution;
+        public FT_UInt vertResolution; 
+    }
+}

--- a/FreeTypeSharp/Native/FT_Size_Request_Type.cs
+++ b/FreeTypeSharp/Native/FT_Size_Request_Type.cs
@@ -1,0 +1,13 @@
+﻿namespace FreeTypeSharp.Native
+{
+    public enum FT_Size_Request_Type
+    {
+        FT_SIZE_REQUEST_TYPE_NOMINAL = 0,
+        FT_SIZE_REQUEST_TYPE_REAL_DIM,
+        FT_SIZE_REQUEST_TYPE_BBOX,
+        FT_SIZE_REQUEST_TYPE_CELL,
+        FT_SIZE_REQUEST_TYPE_SCALES,
+
+        FT_SIZE_REQUEST_TYPE_MAX
+    }
+}


### PR DESCRIPTION
This PR fix #19

Follows a sample code:

```csharp
using System;
using FreeTypeSharp.Native;
using static FreeTypeSharp.Native.FT;
using static System.Math;
using System.IO;

namespace FreeTypeSharp.Core.Test
{
    class Program
    {
        const FT_Error ok = FT_Error.FT_Err_Ok;

        static void Main(string[] args)
        {
            var library = new FreeTypeLibrary();
            FT_Library_Version(library.Native, out var major, out var minor, out var patch);
            Console.WriteLine($"FreeType version: {major}.{minor}.{patch}");

            var face = IntPtr.Zero;
            var lib = IntPtr.Zero;

            if (FT_Init_FreeType(out lib) != ok)
                throw new Exception($"error init freetype");

            foreach (var ft_fontpath in Directory.GetFiles("/usr/share/fonts/truetype/", "*.ttf", SearchOption.AllDirectories))
            {
                if (Path.GetFileName(ft_fontpath) == "NotoColorEmoji.ttf") continue;

                if (FT_New_Face(lib, ft_fontpath, 0, out face) != ok)
                    throw new Exception($"error freetype font path {ft_fontpath}");

                //

                // 26.6 fractional pixel ( unit = 1/64 pixel )
                ulong pixel_to_fpx_26_6(int pixel) => (ulong)pixel * 64;
                int fpx26_6_to_pixel(ulong fpx) => (int)(fpx / 64);

                FT_Size_RequestRec req;
                req.type = FT_Size_Request_Type.FT_SIZE_REQUEST_TYPE_NOMINAL;
                req.width = pixel_to_fpx_26_6(100);
                req.height = pixel_to_fpx_26_6(100);
                req.horiResolution = 0;
                req.vertResolution = 0;

                unsafe
                {
                    if (FT_Request_Size(face, (IntPtr)((void*)&req)) != ok)
                        throw new Exception("req size");
                }

                var c = FT_Get_First_Char(face, out var char_idx);

                int? hAdvMin = null;
                int? hAdvMax = null;
                int? vAdvMin = null;
                int? vAdvMax = null;

                while (char_idx != 0)
                {

                    if (FT_Load_Char(face, c, FT_LOAD_RENDER) != ok)
                        throw new Exception("load char");

                    unsafe
                    {
                        var f = (FT_FaceRec*)face;

                        var metrics = f->glyph->metrics;

                        var K = 64;

                        var width = fpx26_6_to_pixel((ulong)metrics.width);
                        var height = fpx26_6_to_pixel((ulong)metrics.height);

                        var hAdvance = fpx26_6_to_pixel((ulong)metrics.horiAdvance);
                        var hBearingX = fpx26_6_to_pixel((ulong)metrics.horiBearingX);
                        var hBearingY = fpx26_6_to_pixel((ulong)metrics.horiBearingY);
                        hAdvMin = hAdvMin is null ? hAdvance : Min(hAdvMin.Value, hAdvance);
                        hAdvMax = hAdvMax is null ? hAdvance : Max(hAdvMax.Value, hAdvance);

                        var vAdvance = fpx26_6_to_pixel((ulong)metrics.vertAdvance);
                        var vBearingX = fpx26_6_to_pixel((ulong)metrics.vertBearingX);
                        var vBearingY = fpx26_6_to_pixel((ulong)metrics.vertBearingY);
                        vAdvMin = vAdvMin is null ? vAdvance : Min(vAdvMin.Value, vAdvance);
                        vAdvMax = vAdvMax is null ? vAdvance : Max(vAdvMax.Value, vAdvance);

                        var bmpW = f->glyph->bitmap.width;
                        var bmpH = f->glyph->bitmap.rows;
                    }

                    c = FT_Get_Next_Char(face, c, out char_idx);
                }

                FT_Done_Face(face);

                System.Console.WriteLine($"hAdv:{hAdvMin,5},{hAdvMax,5}\tvAdv:{vAdvMin,5},{vAdvMax,5}\t{ft_fontpath}");
            }

            FT_Done_FreeType(lib);
        }
    }
}
```

with results as:

```
FreeType version: 2.11.0
hAdv:    0,  107	vAdv:  159,  159	/usr/share/fonts/truetype/fonts-kalapi/Kalapi.ttf
hAdv:    0,  108	vAdv:   97,   98	/usr/share/fonts/truetype/pagul/Pagul.ttf
hAdv:    0,  111	vAdv:  188,  188	/usr/share/fonts/truetype/tlwg/Garuda-BoldOblique.ttf
hAdv:    0,  161	vAdv:  170,  170	/usr/share/fonts/truetype/tlwg/Norasi-Oblique.ttf
hAdv:    0,  126	vAdv:  159,  159	/usr/share/fonts/truetype/tlwg/Loma.ttf
hAdv:    0,  164	vAdv:  170,  170	/usr/share/fonts/truetype/tlwg/Norasi-BoldItalic.ttf
hAdv:   60,   60	vAdv:  123,  123	/usr/share/fonts/truetype/tlwg/TlwgMono-Bold.ttf
hAdv:   60,   60	vAdv:  123,  123	/usr/share/fonts/truetype/tlwg/TlwgMono-BoldOblique.ttf
hAdv:    0,  154	vAdv:  178,  178	/usr/share/fonts/truetype/tlwg/Kinnari.ttf
hAdv:    0,  139	vAdv:  159,  159	/usr/share/fonts/truetype/tlwg/Loma-Bold.ttf
hAdv:    0,  146	vAdv:  178,  178	/usr/share/fonts/truetype/tlwg/Kinnari-BoldItalic.ttf
hAdv:    0,  125	vAdv:  198,  198	/usr/share/fonts/truetype/tlwg/Umpush-LightOblique.ttf
hAdv:    0,  180	vAdv:  132,  132	/usr/share/fonts/truetype/tlwg/TlwgTypewriter.ttf
hAdv:    0,  154	vAdv:  178,  178	/usr/share/fonts/truetype/tlwg/Kinnari-Oblique.ttf
hAdv:    0,  146	vAdv:  166,  166	/usr/share/fonts/truetype/tlwg/Laksaman-Bold.ttf
hAdv:    0,  125	vAdv:  198,  198	/usr/share/fonts/truetype/tlwg/Umpush-Light.ttf
hAdv:   60,   60	vAdv:  125,  125	/usr/share/fonts/truetype/tlwg/TlwgTypo-Oblique.ttf
...


hAdv:    0,   60	vAdv:   80,   80	/usr/share/fonts/truetype/liberation2/LiberationMono-Italic.ttf
hAdv:    0,  134	vAdv:   94,   94	/usr/share/fonts/truetype/liberation2/LiberationSans-Regular.ttf
hAdv:    0,   60	vAdv:   84,   84	/usr/share/fonts/truetype/liberation2/LiberationMono-Bold.ttf
hAdv:    0,  133	vAdv:   89,   89	/usr/share/fonts/truetype/liberation2/LiberationSerif-BoldItalic.ttf
hAdv:    0,  133	vAdv:   94,   94	/usr/share/fonts/truetype/liberation2/LiberationSans-Italic.ttf
hAdv:    0,  171	vAdv:  234,  234	/usr/share/fonts/truetype/lohit-telugu/Lohit-Telugu.ttf
hAdv:    0,  157	vAdv:  147,  147	/usr/share/fonts/truetype/Gubbi/Gubbi.ttf
hAdv:    0,  160	vAdv:  100,  100	/usr/share/fonts/truetype/freefont/FreeSerifItalic.ttf
hAdv:    0,   60	vAdv:  100,  100	/usr/share/fonts/truetype/freefont/FreeMonoBold.ttf
hAdv:    0,  167	vAdv:  100,  100	/usr/share/fonts/truetype/freefont/FreeSerifBoldItalic.ttf
hAdv:    0,  185	vAdv:  100,  100	/usr/share/fonts/truetype/freefont/FreeSerifBold.ttf
hAdv:    0,  147	vAdv:  100,  100	/usr/share/fonts/truetype/freefont/FreeSansBold.ttf
hAdv:    0,  150	vAdv:  100,  100	/usr/share/fonts/truetype/freefont/FreeSansOblique.ttf
hAdv:    0,  168	vAdv:  100,  100	/usr/share/fonts/truetype/freefont/FreeSerif.ttf
hAdv:    0,  190	vAdv:  100,  100	/usr/share/fonts/truetype/freefont/FreeSans.ttf
hAdv:    0,   60	vAdv:  100,  100	/usr/share/fonts/truetype/freefont/FreeMono.ttf
hAdv:    0,  150	vAdv:  100,  100	/usr/share/fonts/truetype/freefont/FreeSansBoldOblique.ttf
hAdv:    0,   60	vAdv:  100,  100	/usr/share/fonts/truetype/freefont/FreeMonoOblique.ttf
hAdv:    0,   60	vAdv:  100,  100	/usr/share/fonts/truetype/freefont/FreeMonoBoldOblique.ttf
```